### PR TITLE
Keep browser open after client shutdown

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -846,7 +846,6 @@ class Client extends EventEmitter {
      * Closes the client
      */
     async destroy() {
-        await this.pupBrowser.close();
         await this.authStrategy.destroy();
     }
 
@@ -859,14 +858,6 @@ class Client extends EventEmitter {
                 return window.Store.AppState.logout();
             }
         });
-        await this.pupBrowser.close();
-        
-        let maxDelay = 0;
-        while (this.pupBrowser.isConnected() && (maxDelay < 10)) { // waits a maximum of 1 second before calling the AuthStrategy
-            await new Promise(resolve => setTimeout(resolve, 100));
-            maxDelay++; 
-        }
-        
         await this.authStrategy.logout();
     }
 


### PR DESCRIPTION
## Summary
- prevent the client from closing the Puppeteer browser during destroy and logout so the UI stays available after scripts finish

## Testing
- npm test -- --runInBand *(fails: The WWEBJS_TEST_REMOTE_ID environment variable has not been set.)*

------
https://chatgpt.com/codex/tasks/task_e_68e143c359e083238bbae6d8eba4bef5