### PR TITLE
Add manual opt-out handling to bulk sender CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ node bulk-sender.js ./ruta/al/archivo.xlsx 7000
 ```
 
 * El segundo argumento define el retraso mínimo en milisegundos entre mensajes (por defecto `5000`).
+* Usa la opción `--optout <numero>` para registrar manualmente números que no deben volver a recibir mensajes. Puedes repetir la opción varias veces y los números se guardarán en `optout.txt` (o en la ruta definida por `BULK_OPTOUT_FILE`). Ejemplo: `node bulk-sender.js contactos.xlsx --optout 4141234567 --optout 4247654321`.
 * Variables de entorno disponibles:
   * `BULK_DEFAULT_COUNTRY_CODE`: Prefijo de país que se añadirá si el número no lo incluye.
   * `BULK_MESSAGE_TEMPLATE`: Plantilla de mensaje; admite los marcadores `{name}` y `{phone}`.
   * `BULK_MIN_DELAY_MS`: Retraso mínimo cuando no se pasa como argumento.
+  * `BULK_OPTOUT_FILE`: Ruta del archivo donde se almacenan los números en opt-out (por defecto `optout.txt`).
 * Los números se normalizan automáticamente (sin espacios, `+`, `00` inicial ni ceros sobrantes) y se omiten los registros con menos de 8 dígitos tras la limpieza.
 
 ## Funcionalidades admitidas

--- a/bulk-sender.js
+++ b/bulk-sender.js
@@ -11,7 +11,8 @@ const STATUS_LAST_CHECKED_COLUMN = 'whatsapp_last_checked';
 const STATUS_VALUES = {
     invalid: 'INVALID_NUMBER',
     notRegistered: 'NOT_REGISTERED',
-    registered: 'REGISTERED'
+    registered: 'REGISTERED',
+    optOut: 'OPT_OUT'
 };
 
 const FORCE_REVALIDATE = String(process.env.BULK_FORCE_REVALIDATE || '').toLowerCase() === 'true';
@@ -48,6 +49,9 @@ const DEFAULT_MIN_DELAY = Number.parseInt(process.env.BULK_MIN_DELAY_MS, 10) || 
 const VALIDATION_DELAY = Number.parseInt(process.env.BULK_VALIDATION_DELAY_MS, 10) || 2000;
 const MESSAGE_TEMPLATE_ENV = process.env.BULK_MESSAGE_TEMPLATE || 'Hola {name}, este es un mensaje automatizado.';
 const MESSAGE_FILE_ENV = process.env.BULK_MESSAGE_FILE;
+const OPT_OUT_FILE_ENV = process.env.BULK_OPTOUT_FILE;
+const DEFAULT_OPT_OUT_FILE = 'optout.txt';
+const OPT_OUT_FILE_PATH = path.resolve(process.cwd(), OPT_OUT_FILE_ENV || DEFAULT_OPT_OUT_FILE);
 
 const VENEZUELA_COUNTRY_CODE = '58';
 const VENEZUELA_PREFIXES = ['412', '422', '416', '426', '414', '424'];
@@ -95,6 +99,91 @@ function normalizePhoneNumber(input) {
         id: `${normalized}@c.us`,
         display: normalized
     };
+}
+
+function normalizeOptOutEntry(input) {
+    const normalized = normalizePhoneNumber(input);
+
+    if (!normalized) {
+        return null;
+    }
+
+    return normalized.display;
+}
+
+function persistOptOutNumbers(filePath, numbersSet) {
+    const sorted = Array.from(numbersSet).sort();
+    const data = sorted.join('\n');
+    const content = sorted.length > 0 ? `${data}\n` : '';
+
+    fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function loadOptOutNumbers(filePath) {
+    if (!fs.existsSync(filePath)) {
+        return new Set();
+    }
+
+    const rawEntries = fs.readFileSync(filePath, 'utf8')
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean);
+
+    const normalizedNumbers = new Set();
+    let needsPersistence = false;
+
+    for (const entry of rawEntries) {
+        const normalized = normalizeOptOutEntry(entry);
+
+        if (!normalized) {
+            console.warn(`Entrada inválida en la lista de opt-out: "${entry}". Se ignorará.`);
+            needsPersistence = true;
+            continue;
+        }
+
+        normalizedNumbers.add(normalized);
+
+        if (normalized !== entry) {
+            needsPersistence = true;
+        }
+    }
+
+    if (needsPersistence) {
+        persistOptOutNumbers(filePath, normalizedNumbers);
+    }
+
+    return normalizedNumbers;
+}
+
+function applyOptOutUpdates(entries, optOutNumbers, filePath) {
+    if (!entries || entries.length === 0) {
+        return false;
+    }
+
+    let updated = false;
+
+    for (const entry of entries) {
+        const normalized = normalizeOptOutEntry(entry);
+
+        if (!normalized) {
+            console.warn(`No se pudo interpretar el número de opt-out "${entry}". Se ignora.`);
+            continue;
+        }
+
+        if (optOutNumbers.has(normalized)) {
+            continue;
+        }
+
+        optOutNumbers.add(normalized);
+        console.log(`Número ${normalized} añadido a la lista de opt-out.`);
+        updated = true;
+    }
+
+    if (updated) {
+        persistOptOutNumbers(filePath, optOutNumbers);
+    }
+
+    return updated;
 }
 
 /**
@@ -209,7 +298,7 @@ function createWorkbookContext(workbookPath, workbook, sheetName) {
     };
 }
 
-function readContactsFromWorkbook(workbookPath) {
+function readContactsFromWorkbook(workbookPath, optOutNumbers) {
     const absolutePath = path.resolve(workbookPath);
 
     if (!fs.existsSync(absolutePath)) {
@@ -226,6 +315,8 @@ function readContactsFromWorkbook(workbookPath) {
     const sheet = workbook.Sheets[firstSheetName];
     const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
     const context = createWorkbookContext(absolutePath, workbook, firstSheetName);
+
+    const optOutSet = optOutNumbers instanceof Set ? optOutNumbers : new Set();
 
     const contacts = rows
         .map((row, index) => {
@@ -246,11 +337,22 @@ function readContactsFromWorkbook(workbookPath) {
                 return null;
             }
 
+            if (normalizedStatus === STATUS_VALUES.optOut) {
+                console.warn(`Fila ${rowNumber}: Marcado previamente como opt-out. Se omite el contacto.`);
+                return null;
+            }
+
             const normalized = normalizePhoneNumber(telefono);
 
             if (!normalized) {
                 console.warn(`Fila ${rowNumber}: Número inválido u omitido. Se omite el contacto.`);
                 context.queueStatus(rowNumber, STATUS_VALUES.invalid, 'Número inválido u omitido.');
+                return null;
+            }
+
+            if (optOutSet.has(normalized.display)) {
+                console.warn(`Fila ${rowNumber}: Número en lista de opt-out. Se omite el contacto.`);
+                context.queueStatus(rowNumber, STATUS_VALUES.optOut, 'Número en lista de opt-out.');
                 return null;
             }
 
@@ -360,15 +462,77 @@ function resolveMessageTemplate() {
     return null;
 }
 
-async function main() {
-    const [,, excelPath, minDelayArg] = process.argv;
+function parseArguments(argv) {
+    const positional = [];
+    const optOutEntries = [];
 
-    if (!excelPath) {
-        console.error('Uso: node bulk-sender.js <ruta_excel> [delay_ms]');
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+
+        if (argument === '--optout') {
+            const value = argv[index + 1];
+
+            if (value === undefined) {
+                throw new Error('Falta un número después de --optout.');
+            }
+
+            optOutEntries.push(value);
+            index += 1;
+            continue;
+        }
+
+        if (argument.startsWith('--optout=')) {
+            const value = argument.slice('--optout='.length);
+
+            if (!value) {
+                throw new Error('Falta un número después de --optout=.');
+            }
+
+            optOutEntries.push(value);
+            continue;
+        }
+
+        positional.push(argument);
+    }
+
+    return { positional, optOutEntries };
+}
+
+async function main() {
+    let parsedArguments;
+
+    try {
+        parsedArguments = parseArguments(process.argv.slice(2));
+    } catch (error) {
+        console.error(error.message);
+        console.error('Uso: node bulk-sender.js <ruta_excel> [delay_ms] [--optout <numero> ...]');
         process.exit(1);
     }
 
+    const { positional, optOutEntries } = parsedArguments;
+    const [excelPath, minDelayArg, ...extraPositionals] = positional;
+
+    if (!excelPath) {
+        console.error('Uso: node bulk-sender.js <ruta_excel> [delay_ms] [--optout <numero> ...]');
+        process.exit(1);
+    }
+
+    if (extraPositionals.length > 0) {
+        console.warn(`Argumentos posicionales adicionales ignorados: ${extraPositionals.join(', ')}`);
+    }
+
     const minDelayMs = Number.parseInt(minDelayArg, 10) || DEFAULT_MIN_DELAY;
+
+    const optOutNumbers = loadOptOutNumbers(OPT_OUT_FILE_PATH);
+    const optOutUpdated = applyOptOutUpdates(optOutEntries, optOutNumbers, OPT_OUT_FILE_PATH);
+
+    if (optOutNumbers.size > 0) {
+        console.log(`Lista de opt-out cargada (${optOutNumbers.size} números) desde ${OPT_OUT_FILE_PATH}.`);
+    }
+
+    if (optOutEntries.length > 0 && !optOutUpdated) {
+        console.warn('No se añadieron números válidos a la lista de opt-out.');
+    }
 
     const templateFromFile = resolveMessageTemplate();
 
@@ -380,7 +544,7 @@ async function main() {
     }
 
     console.log(`Leyendo contactos desde ${excelPath}...`);
-    const { contacts, context } = readContactsFromWorkbook(excelPath);
+    const { contacts, context } = readContactsFromWorkbook(excelPath, optOutNumbers);
     workbookContext = context;
     console.log(`Contactos válidos: ${contacts.length}`);
 

--- a/docs/bulk-sender.md
+++ b/docs/bulk-sender.md
@@ -13,12 +13,14 @@ El script `bulk-sender.js` añade columnas de estado para cada contacto cuando s
 | `INVALID_NUMBER`          | El número no tiene el formato venezolano esperado o la fila no incluye número |
 | `NOT_REGISTERED`          | El número existe pero no está afiliado a WhatsApp                             |
 | `REGISTERED`              | El número se validó como activo en WhatsApp                                   |
+| `OPT_OUT`                 | El número fue marcado manualmente para no ser contactado                      |
 
 Además se almacena un mensaje de contexto y una marca de tiempo ISO en las otras dos columnas.
 
 ## ¿Qué ocurre en siguientes ejecuciones?
 
 * Si una fila está marcada como `INVALID_NUMBER` o `NOT_REGISTERED`, el script la omite automáticamente en ejecuciones futuras para evitar validar el mismo número una y otra vez.
+* Si una fila está marcada como `OPT_OUT`, nunca volverá a enviarse un mensaje a ese contacto aunque se active la revalidación forzada; el estado solo puede cambiarse editando el Excel manualmente.
 * Si una fila está marcada como `REGISTERED`, el script asume que sigue siendo válido y tampoco vuelve a consultar a WhatsApp. Añade la nota `"Validación omitida (resultado previo)."` en la columna de mensajes.
 * Si necesitas forzar la revalidación de todos los números, establece la variable de entorno `BULK_FORCE_REVALIDATE=true` antes de ejecutar el script.
 


### PR DESCRIPTION
## Summary
- add a `--optout` CLI flag that stores normalized numbers in a persistent file and skips them when processing the workbook
- mark opt-out contacts in the Excel status column so they are never reprocessed and document the new state
- document the new CLI option, environment variable, and behaviour in the bulk sender guide

## Testing
- npm test *(fails: The WWEBJS_TEST_REMOTE_ID environment variable has not been set)*

------
https://chatgpt.com/codex/tasks/task_e_68e5260a21d483239688cf32996327f4