### PR TITLE
Allow updating opt-out list without workbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ node bulk-sender.js ./ruta/al/archivo.xlsx 7000
 ```
 
 * El segundo argumento define el retraso mínimo en milisegundos entre mensajes (por defecto `5000`).
+* Usa la opción `--optout <numero>` para registrar manualmente números que no deben volver a recibir mensajes. Puedes repetir la opción varias veces y los números se guardarán en `optout.txt` (o en la ruta definida por `BULK_OPTOUT_FILE`). Ejemplo durante un envío: `node bulk-sender.js contactos.xlsx --optout 4141234567 --optout 4247654321`.
+* También puedes añadir números sin procesar un Excel ejecutando solo la opción: `node bulk-sender.js --optout 4141234567`. El script actualizará el archivo de opt-out y terminará inmediatamente.
 * Variables de entorno disponibles:
   * `BULK_DEFAULT_COUNTRY_CODE`: Prefijo de país que se añadirá si el número no lo incluye.
   * `BULK_MESSAGE_TEMPLATE`: Plantilla de mensaje; admite los marcadores `{name}` y `{phone}`.
   * `BULK_MIN_DELAY_MS`: Retraso mínimo cuando no se pasa como argumento.
+  * `BULK_OPTOUT_FILE`: Ruta del archivo donde se almacenan los números en opt-out (por defecto `optout.txt`).
 * Los números se normalizan automáticamente (sin espacios, `+`, `00` inicial ni ceros sobrantes) y se omiten los registros con menos de 8 dígitos tras la limpieza.
 
 ## Funcionalidades admitidas

--- a/docs/bulk-sender.md
+++ b/docs/bulk-sender.md
@@ -13,12 +13,26 @@ El script `bulk-sender.js` añade columnas de estado para cada contacto cuando s
 | `INVALID_NUMBER`          | El número no tiene el formato venezolano esperado o la fila no incluye número |
 | `NOT_REGISTERED`          | El número existe pero no está afiliado a WhatsApp                             |
 | `REGISTERED`              | El número se validó como activo en WhatsApp                                   |
+| `OPT_OUT`                 | El número fue marcado manualmente para no ser contactado                      |
 
 Además se almacena un mensaje de contexto y una marca de tiempo ISO en las otras dos columnas.
+
+## ¿Cómo marco manualmente un opt-out?
+
+Ejecuta el script con la opción `--optout` y el número en formato venezolano sin símbolos (`4141234567`, `4247654321`, etc.). Puedes repetir la opción tantas veces como necesites y los valores se guardarán en `optout.txt` (o en la ruta definida por `BULK_OPTOUT_FILE`).
+
+```bash
+node bulk-sender.js --optout 4141234567
+# o durante un envío masivo
+node bulk-sender.js contactos.xlsx --optout 4141234567 --optout 4247654321
+```
+
+Cuando se ejecuta solo con `--optout`, el script actualiza el archivo y termina sin abrir el libro de Excel.
 
 ## ¿Qué ocurre en siguientes ejecuciones?
 
 * Si una fila está marcada como `INVALID_NUMBER` o `NOT_REGISTERED`, el script la omite automáticamente en ejecuciones futuras para evitar validar el mismo número una y otra vez.
+* Si una fila está marcada como `OPT_OUT`, nunca volverá a enviarse un mensaje a ese contacto aunque se active la revalidación forzada; el estado solo puede cambiarse editando el Excel manualmente.
 * Si una fila está marcada como `REGISTERED`, el script asume que sigue siendo válido y tampoco vuelve a consultar a WhatsApp. Añade la nota `"Validación omitida (resultado previo)."` en la columna de mensajes.
 * Si necesitas forzar la revalidación de todos los números, establece la variable de entorno `BULK_FORCE_REVALIDATE=true` antes de ejecutar el script.
 


### PR DESCRIPTION
## Summary
- allow running the bulk sender with only the `--optout` flag to update the persistent list without opening a workbook
- log helpful messages for standalone opt-out updates and document the new usage in the README and bulk sender guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5260a21d483239688cf32996327f4